### PR TITLE
Switch to ts-json-schema-generator instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "json5": "^2.1.1",
-    "typescript-json-schema": "^0.42.0"
+    "ts-json-schema-generator": "0.76.1"
   },
   "peerDependencies": {
     "typescript": "^3.5.3"}

--- a/src/from-type.ts
+++ b/src/from-type.ts
@@ -1,7 +1,7 @@
-import { Args, Definition } from "typescript-json-schema";
+import { Config, Definition } from "ts-json-schema-generator";
 
-export { Args, Definition };
+export { Config, Definition };
 
-export function fromType<T>(args?: Partial<Args>): Definition | null {
+export function fromType<T>(args?: Partial<Config>): Definition | null {
     throw new Error("fromType should not be used during runtime, apply ts-transform-json-schema instead");
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import * as tjs from "typescript-json-schema";
+import * as tjs from "ts-json-schema-generator";
 import * as JSON5 from "json5";
 
 const packageName = "env0-ts-transform-json-schema";
@@ -45,19 +45,21 @@ export const getTransformer = (program: ts.Program) => {
             throw new Error(`Could not find symbol for passed type`);
           }
 
-          // ignoring since generateTSConfig is undeclared (but exported)
-          // @ts-ignore
-          const configAsString = ts.generateTSConfig(ctx.getCompilerOptions(), [], '\n');
-          const tsconfig = JSON5.parse(configAsString);
-          const compilerOptions = Object.fromEntries(
-              Object.keys(ctx.getCompilerOptions()).map(key => [key, tsconfig.compilerOptions[key]])
-          );
-
-          const apiFiles = program.getSourceFiles().map(f => f.fileName).filter(n => n.endsWith('/api.d.ts'));
-          const apiProgram = tjs.getProgramFromFiles(apiFiles, compilerOptions);
-          const generator = tjs.buildGenerator(apiProgram, options);
+          const tsconfig = ctx.getCompilerOptions().configFilePath as string;
+          let projectApi = tsconfig.replace('tsconfig.json', 'api.d.ts');
+          const apiFiles = program.getSourceFiles().map(f => f.fileName).filter(n => n === projectApi);
+          if(apiFiles.length > 1) throw `Found too many files matching ${apiFiles}`
           const namespacedTypeName = typeChecker.getFullyQualifiedName(symbol).replace(/".*"\./, "");
-          const schema = generator.getSchemaForSymbol(namespacedTypeName);
+
+          const config = {
+            path: apiFiles[0],
+            tsconfig,
+            type: namespacedTypeName,
+            ...options
+          };
+
+          const generator = tjs.createGenerator(config);
+          const schema = generator.createSchema(config.type);
 
           return toLiteral(schema);
         }
@@ -109,7 +111,7 @@ function toLiteral(input: unknown): ts.PrimaryExpression {
   return ts.createNull();
 }
 
-function getOptions(node: ts.Node): unknown {
+function getOptions(node: ts.Node): object {
   try {
     return JSON5.parse(node.getText());
   } catch (err) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -46,13 +46,15 @@ export const getTransformer = (program: ts.Program) => {
           }
 
           const tsconfig = ctx.getCompilerOptions().configFilePath as string;
-          let projectApi = tsconfig.replace('tsconfig.json', 'api.d.ts');
-          const apiFiles = program.getSourceFiles().map(f => f.fileName).filter(n => n === projectApi);
-          if(apiFiles.length > 1) throw `Found too many files matching ${apiFiles}`
+          const projectApi = tsconfig.replace('tsconfig.json', 'api.d.ts');
+          const hasApiFile = program.getSourceFiles().map(f => f.fileName).includes(projectApi);
+
+          if(!hasApiFile) throw 'Project must have an api.d.ts file that includes the type'
+
           const namespacedTypeName = typeChecker.getFullyQualifiedName(symbol).replace(/".*"\./, "");
 
           const config = {
-            path: apiFiles[0],
+            path: projectApi,
             tsconfig,
             type: namespacedTypeName,
             ...options


### PR DESCRIPTION
https://github.com/YousefED/typescript-json-schema builds the schema for ALL types.  
We're looking to get only that of one type (the one provided as generic in `ForType<>`).  
This causes severe performance issues.  
Switched to use https://github.com/vega/ts-json-schema-generator instead