### PR TITLE
Reuse generator when possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "env0-ts-transform-json-schema",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Generate inline JSON schema from TypeScript types",
   "files": [
     "lib",


### PR DESCRIPTION
Building a schema generator (more precisely, building the TypeScript `program` it uses), is **very** costly.  
Trials show 5-6s in large projects.  

Right now if `JsonSchema.fromType<>()` is used `n` times, this generator (and the TypeScript program that comes with it), will be built `n` times.  

In most cases, the generator and its program can be reused - shaving off precious build minutes and memory pressure.  
The only exception is when `JsonSchema.fromType<>()` is given the optional argument to change the generator config - in this case, a new generator will be built and used instead of the default one.  

So in most cases, this PR will introduce an optimization making the transformer it `n` times faster.  

## Next optimization steps
Since we're running within a TypeScript program, maybe we'd would be able to reuse the `program` that is being transpiled right now instead of creating a new one.  

That should shave off those final seconds.  

```typescript
const formatter = tjs.createFormatter(config);
const parser = tjs.createParser(program, config);
const generator = new tjs.SchemaGenerator(program, parser, formatter, config);
const schema = generator.createSchema(config.type);
```